### PR TITLE
Refactor Creacional - Asignación de estado después de construcción - Jesus Antonio Triana Corvera - anexo md 

### DIFF
--- a/practicas/creacionales/fix/Asignación de estado después de construcción/anexo.md
+++ b/practicas/creacionales/fix/Asignación de estado después de construcción/anexo.md
@@ -1,0 +1,9 @@
+Genera un archivo .md que explique el antipatrón **Asignación de estado después de construcción** cuando se usa mal el patrón Builder.  
+Incluye las secciones de la rúbrica:  
+
+1. Identificación de problemas (30%)  
+2. Aplicación correcta del patrón (30%)  
+3. Justificación técnica (40%)  
+
+Usa un ejemplo en el dominio de **vehículos** (clase Vehicle con propiedades como Engine, Transmission, BrakeSystem).  
+Mantén un tono técnico, con ejemplos de código en C#.  

--- a/practicas/creacionales/fix/Asignación de estado después de construcción/readme.md
+++ b/practicas/creacionales/fix/Asignación de estado después de construcción/readme.md
@@ -1,0 +1,154 @@
+# Antipatrón: Asignación de estado después de construcción (Builder) — Dominio: Vehículo
+Jesus Antonio Triana Corvera - C20212681
+---
+
+## 1. Identificación de problemas 
+
+### Situación
+- `VehicleBuilder.Build()` retorna una instancia **incompleta** (`Vehicle`) y el cliente completa propiedades críticas *después* (motor, transmisión, frenos).  
+- Entre `Build()` y las asignaciones tardías existe una **ventana de inconsistencia** donde no se cumplen invariantes (p. ej., un vehículo sin sistema de frenos).
+
+### Problemas detectados
+- **Inmutabilidad rota**: `Vehicle` expone setters públicos para atributos esenciales.  
+- **Validación dispersa**: no hay control centralizado en `Build()`; errores aparecen en tiempo de uso.  
+- **Acoplamiento al orden**: la lógica depende del *sequence* de setters post-`Build()`.  
+- **Fragilidad en tests**: setups largos con riesgo de omitir propiedades obligatorias.  
+
+**Ejemplo (antipatrón):**
+```csharp
+public class Vehicle
+{
+    public string Model { get; set; }
+    public Engine Engine { get; set; }
+    public Transmission Transmission { get; set; }
+    public BrakeSystem BrakeSystem { get; set; }
+}
+
+public class VehicleBuilder
+{
+    private string _model;
+
+    public VehicleBuilder WithModel(string model) { _model = model; return this; }
+
+    // Mala práctica: retorna vehículo incompleto
+    public Vehicle Build() => new Vehicle { Model = _model };
+}
+
+// Uso → antipatrón
+var v = new VehicleBuilder()
+    .WithModel("Sedan-X")
+    .Build();
+
+// Asignaciones tardías (estado crítico; orden importa)
+v.Engine = new GasEngine(180);
+v.Transmission = new Automatic6();
+v.BrakeSystem = new AbsBrakes();
+```
+
+**Efectos:** `v` puede “escaparse” a otros componentes **antes** de tener frenos o transmisión, generando fallos intermitentes o NPEs.
+
+---
+
+## 2. Aplicación correcta del patrón 
+
+### Solución aplicada
+- Consolidar **todos los requisitos obligatorios** en el Builder.  
+- `Build()` **valida** invariantes y entrega un objeto **consistente**.  
+- Propiedades críticas solo lectura (`get`) o `init`; setters públicos eliminados.  
+
+**Refactor (Builder correcto):**
+```csharp
+public class Vehicle
+{
+    public string Model { get; }
+    public Engine Engine { get; }
+    public Transmission Transmission { get; }
+    public BrakeSystem BrakeSystem { get; }
+
+    internal Vehicle(string model, Engine engine, Transmission transmission, BrakeSystem brakes)
+    {
+        Model = model;
+        Engine = engine;
+        Transmission = transmission;
+        BrakeSystem = brakes;
+    }
+}
+
+public class VehicleBuilder
+{
+    private string _model;
+    private Engine _engine;
+    private Transmission _transmission;
+    private BrakeSystem _brakes;
+
+    public VehicleBuilder WithModel(string model) { _model = model; return this; }
+    public VehicleBuilder WithEngine(Engine engine) { _engine = engine; return this; }
+    public VehicleBuilder WithTransmission(Transmission transmission) { _transmission = transmission; return this; }
+    public VehicleBuilder WithBrakes(BrakeSystem brakes) { _brakes = brakes; return this; }
+
+    public Vehicle Build()
+    {
+        if (string.IsNullOrWhiteSpace(_model)) throw new InvalidOperationException("Model requerido");
+        if (_engine is null) throw new InvalidOperationException("Engine requerido");
+        if (_transmission is null) throw new InvalidOperationException("Transmission requerida");
+        if (_brakes is null) throw new InvalidOperationException("BrakeSystem requerido");
+
+        return new Vehicle(_model, _engine, _transmission, _brakes);
+    }
+}
+```
+
+### Variante (si hay condicionamiento por tipo de motor)
+Para encapsular la creación de motores/transmisiones dependientes del *trim* o combustible, utilizar **Factory Method/Abstract Factory** y pasar la factory al Builder, evitando asignación tardía y *switches* externos.
+
+```csharp
+public abstract class DrivetrainFactory
+{
+    public abstract Engine CreateEngine();
+    public abstract Transmission CreateTransmission();
+}
+
+public class HybridDrivetrainFactory : DrivetrainFactory
+{
+    public override Engine CreateEngine() => new HybridEngine(110, 60); // ICE + e-motor
+    public override Transmission CreateTransmission() => new ECVT();
+}
+
+public class VehicleBuilderV2
+{
+    private string _model;
+    private DrivetrainFactory _drivetrainFactory;
+    private BrakeSystem _brakes;
+
+    public VehicleBuilderV2 WithModel(string model) { _model = model; return this; }
+    public VehicleBuilderV2 WithDrivetrain(DrivetrainFactory factory) { _drivetrainFactory = factory; return this; }
+    public VehicleBuilderV2 WithBrakes(BrakeSystem brakes) { _brakes = brakes; return this; }
+
+    public Vehicle Build()
+    {
+        if (string.IsNullOrWhiteSpace(_model)) throw new InvalidOperationException("Model requerido");
+        if (_drivetrainFactory is null) throw new InvalidOperationException("DrivetrainFactory requerida");
+        if (_brakes is null) throw new InvalidOperationException("BrakeSystem requerido");
+
+        var engine = _drivetrainFactory.CreateEngine();
+        var transmission = _drivetrainFactory.CreateTransmission();
+        return new Vehicle(_model, engine, transmission, _brakes);
+    }
+}
+```
+
+---
+
+## 3. Justificación técnica
+
+- **Consistencia por construcción**: no existe ventana de uso en estado inválido; invariantes se aplican en `Build()`.  
+- **Encapsulamiento**: la lógica de ensamblaje (motor/transmisión/frenos) está centralizada; el cliente no coordina detalles.  
+- **SRP**: `VehicleBuilder` orquesta construcción; `Vehicle` solo modela estado válido.  
+- **OCP**: con *Factory Method/Abstract Factory* se agregan nuevos trenes motrices sin modificar el cliente.  
+- **Testabilidad**: pruebas se simplifican (un único punto de validación; *arrange* corto).  
+- **Menor acoplamiento temporal**: el orden de llamadas post-`Build()` deja de importar.  
+
+---
+
+**Conclusión**  
+El antipatrón proviene de exponer instancias incompletas. El Builder debe **cerrar la construcción** y **validar invariantes**. Cuando existan decisiones de creación dependientes de variantes (híbrido/EV/ICE), introducir una **fábrica** para mantener OCP y evitar asignaciones tardías.

--- a/practicas/creacionales/veterinariaHotel/Program.cs
+++ b/practicas/creacionales/veterinariaHotel/Program.cs
@@ -7,78 +7,50 @@ namespace ClinicaMascotas
     {
         public static void Main(string[] args)
         {
-            var factory = new MascotaFactory();
+            // Aquí hay una mezcla de responsabilidades: hotel, veterinaria, facturación...
+            var dog = new Mascota("Firulais", "Perro");
+            var cat = new Mascota("Mishi", "Gato");
+
             var servicio = new ServicioVeterinario();
+            servicio.RegistrarConsulta(dog.Nombre);
+            servicio.RegistrarVacuna(cat.Nombre);
+
             var hotel = new HotelMascotas();
-
-            var dog = factory.Crear("Perro", "Firulais");
-            var cat = factory.Crear("Gato", "Mishi");
-
-            servicio.RegistrarConsulta(dog);
-            servicio.RegistrarVacuna(dog);
-            servicio.RegistrarConsulta(cat);
-            servicio.RegistrarVacuna(cat);
-
-            hotel.AsignarHabitacion(dog);
-            hotel.AsignarHabitacion(cat);
+            hotel.AsignarHabitacion(dog.Nombre);
+            hotel.AsignarHabitacion(cat.Nombre);
         }
     }
 
-    public abstract class Mascota
+    public class Mascota
     {
-        public string Nombre { get; }
-        public string Tipo { get; }
+        public string Nombre;
+        public string Tipo;
 
-        protected Mascota(string nombre, string tipo)
+        public Mascota(string nombre, string tipo)
         {
-            if (string.IsNullOrWhiteSpace(nombre))
-                throw new ArgumentException("El nombre es obligatorio");
-            if (string.IsNullOrWhiteSpace(tipo))
-                throw new ArgumentException("El tipo es obligatorio");
-
             Nombre = nombre;
             Tipo = tipo;
         }
     }
 
-    public sealed class Perro : Mascota
-    {
-        public Perro(string nombre) : base(nombre, "Perro") { }
-    }
-
-    public sealed class Gato : Mascota
-    {
-        public Gato(string nombre) : base(nombre, "Gato") { }
-    }
-
-    // Factory Method: punto único de creación por Tipo 
-    public interface IMascotaFactory
-    {
-        Mascota Crear(string tipo, string nombre);
-    }
-
-    public sealed class MascotaFactory : IMascotaFactory
-    {
-        public Mascota Crear(string tipo, string nombre) => tipo switch
-        {
-            "Perro" => new Perro(nombre),
-            "Gato"  => new Gato(nombre),
-            _       => throw new NotSupportedException($"Tipo no soportado: {tipo}")
-        };
-    }
-
     public class ServicioVeterinario
     {
-        public void RegistrarConsulta(Mascota m) =>
-            Console.WriteLine($"Consulta registrada para {m.Nombre} ({m.Tipo})");
+        public void RegistrarConsulta(string mascota)
+        {
+            Console.WriteLine($"Consulta registrada para {mascota}");
+        }
 
-        public void RegistrarVacuna(Mascota m) =>
-            Console.WriteLine($"Vacuna aplicada a {m.Nombre} ({m.Tipo})");
+        public void RegistrarVacuna(string mascota)
+        {
+            Console.WriteLine($"Vacuna aplicada a {mascota}");
+        }
     }
 
     public class HotelMascotas
     {
-        public void AsignarHabitacion(Mascota m) =>
-            Console.WriteLine($"Habitación asignada a {m.Nombre} ({m.Tipo})");
+        public void AsignarHabitacion(string mascota)
+        {
+            Console.WriteLine($"Habitación asignada a {mascota}");
+        }
     }
 }

--- a/practicas/creacionales/veterinariaHotel/Program.cs
+++ b/practicas/creacionales/veterinariaHotel/Program.cs
@@ -7,50 +7,78 @@ namespace ClinicaMascotas
     {
         public static void Main(string[] args)
         {
-            // Aquí hay una mezcla de responsabilidades: hotel, veterinaria, facturación...
-            var dog = new Mascota("Firulais", "Perro");
-            var cat = new Mascota("Mishi", "Gato");
-
+            var factory = new MascotaFactory();
             var servicio = new ServicioVeterinario();
-            servicio.RegistrarConsulta(dog.Nombre);
-            servicio.RegistrarVacuna(cat.Nombre);
-
             var hotel = new HotelMascotas();
-            hotel.AsignarHabitacion(dog.Nombre);
-            hotel.AsignarHabitacion(cat.Nombre);
+
+            var dog = factory.Crear("Perro", "Firulais");
+            var cat = factory.Crear("Gato", "Mishi");
+
+            servicio.RegistrarConsulta(dog);
+            servicio.RegistrarVacuna(dog);
+            servicio.RegistrarConsulta(cat);
+            servicio.RegistrarVacuna(cat);
+
+            hotel.AsignarHabitacion(dog);
+            hotel.AsignarHabitacion(cat);
         }
     }
 
-    public class Mascota
+    public abstract class Mascota
     {
-        public string Nombre;
-        public string Tipo;
+        public string Nombre { get; }
+        public string Tipo { get; }
 
-        public Mascota(string nombre, string tipo)
+        protected Mascota(string nombre, string tipo)
         {
+            if (string.IsNullOrWhiteSpace(nombre))
+                throw new ArgumentException("El nombre es obligatorio");
+            if (string.IsNullOrWhiteSpace(tipo))
+                throw new ArgumentException("El tipo es obligatorio");
+
             Nombre = nombre;
             Tipo = tipo;
         }
     }
 
+    public sealed class Perro : Mascota
+    {
+        public Perro(string nombre) : base(nombre, "Perro") { }
+    }
+
+    public sealed class Gato : Mascota
+    {
+        public Gato(string nombre) : base(nombre, "Gato") { }
+    }
+
+    // Factory Method: punto único de creación por Tipo 
+    public interface IMascotaFactory
+    {
+        Mascota Crear(string tipo, string nombre);
+    }
+
+    public sealed class MascotaFactory : IMascotaFactory
+    {
+        public Mascota Crear(string tipo, string nombre) => tipo switch
+        {
+            "Perro" => new Perro(nombre),
+            "Gato"  => new Gato(nombre),
+            _       => throw new NotSupportedException($"Tipo no soportado: {tipo}")
+        };
+    }
+
     public class ServicioVeterinario
     {
-        public void RegistrarConsulta(string mascota)
-        {
-            Console.WriteLine($"Consulta registrada para {mascota}");
-        }
+        public void RegistrarConsulta(Mascota m) =>
+            Console.WriteLine($"Consulta registrada para {m.Nombre} ({m.Tipo})");
 
-        public void RegistrarVacuna(string mascota)
-        {
-            Console.WriteLine($"Vacuna aplicada a {mascota}");
-        }
+        public void RegistrarVacuna(Mascota m) =>
+            Console.WriteLine($"Vacuna aplicada a {m.Nombre} ({m.Tipo})");
     }
 
     public class HotelMascotas
     {
-        public void AsignarHabitacion(string mascota)
-        {
-            Console.WriteLine($"Habitación asignada a {mascota}");
-        }
+        public void AsignarHabitacion(Mascota m) =>
+            Console.WriteLine($"Habitación asignada a {m.Nombre} ({m.Tipo})");
     }
 }


### PR DESCRIPTION
## Problemas detectados
- La clase `Vehicle` expone setters públicos y viola el principio de responsabilidad única.  
- El Builder retorna instancias incompletas, obligando al cliente a asignar dependencias críticas después de `Build()`.  
- La creación de motor y transmisión se hace directamente con `new`, lo que rompe OCP y dificulta la extensibilidad.  

## Patrón aplicado
- Se implementa un **Builder** para garantizar que la construcción de `Vehicle` sea completa y válida en un único paso.  

## Justificación del cambio
- **Cohesión interna**: la construcción de objetos queda centralizada y validada.  
- **Testabilidad**: se simplifica el setup en pruebas al tener un único punto de construcción.  
- **Flexibilidad**: nuevas variantes de motorización o transmisión pueden añadirse sin modificar clientes existentes.  

## Impacto
- Los objetos `Vehicle` siempre se crean en estado consistente.  
- Se eliminan estados intermedios inválidos.  
- Se reduce el acoplamiento y se mejora la mantenibilidad del código.  