### PR TITLE
Reactor Creacional  - Refactor: Crear objetos sin validar estado de Ricardo Rodriguez Carreras

### DIFF
--- a/practicas/creacionales/fix/Crear objetos sin validar estado/readme.md
+++ b/practicas/creacionales/fix/Crear objetos sin validar estado/readme.md
@@ -1,0 +1,166 @@
+RICARDO RODRIGUEZ CARRERAS 21212360
+# Refactor Creacional - Crear objetos sin validar estado
+
+## 🔍 Problemas detectados
+1. **Clase `Celular` permite instancias inválidas**
+   - El constructor acepta parámetros nulos o vacíos (`marca`, `modelo`, `sistema operativo`).
+   - Esto provoca objetos en estado inconsistente.
+
+2. **Uso de `new` directamente en el cliente**
+   - Se crean objetos `Celular` sin ningún mecanismo de validación.
+   - Esto rompe el encapsulamiento y genera duplicación de lógica de validación en distintos lugares.
+
+3. **Falta de separación entre creación y uso**
+   - El cliente decide qué valores asignar y cómo construir el objeto.
+   - Esto viola **SRP**, ya que la validación de estado está mezclada con la lógica de negocio.
+
+---
+
+## 🛠 Patrones aplicados
+- ✅ **Builder con validación interna**: Garantiza que un `Celular` solo se cree si tiene un estado válido.  
+- ✅ **Factory Method**: Centraliza la creación de celulares evitando el uso de `new` disperso.  
+- ✅ **Singleton (Logger seguro en multihilo)**: Registra errores o intentos de creación inválidos.  
+
+---
+
+## 💡 Justificación del cambio
+- Se asegura que **ningún objeto inválido pueda existir** en el sistema.  
+- Se mejora la **cohesión** al centralizar la lógica de construcción.  
+- Se aumenta la **robustez y mantenibilidad** evitando validaciones duplicadas.  
+
+
+---
+
+## 🔄 Impacto
+- Los objetos `Celular` ahora siempre son válidos por construcción.  
+- El código cliente queda más limpio y desacoplado del proceso de validación.  
+- Se prepara la arquitectura para **pruebas unitarias** y extensión futura (ejemplo: distintos tipos de celulares).  
+
+---
+
+## 📌 Ejemplo de Código Refactorizado
+
+### 📱 Clase Producto
+
+public class Celular
+{
+    public string Marca { get; private set; }
+    public string Modelo { get; private set; }
+    public string SistemaOperativo { get; private set; }
+
+    internal Celular(string marca, string modelo, string sistemaOperativo)
+    {
+        Marca = marca;
+        Modelo = modelo;
+        SistemaOperativo = sistemaOperativo;
+    }
+
+    public override string ToString()
+        => $"Celular {Marca} {Modelo} con {SistemaOperativo}";
+}
+
+🏗️ Builder con Validación
+public class CelularBuilder
+{
+    private string _marca;
+    private string _modelo;
+    private string _sistemaOperativo;
+
+    public CelularBuilder ConMarca(string marca)
+    {
+        _marca = marca;
+        return this;
+    }
+
+    public CelularBuilder ConModelo(string modelo)
+    {
+        _modelo = modelo;
+        return this;
+    }
+
+    public CelularBuilder ConSistemaOperativo(string so)
+    {
+        _sistemaOperativo = so;
+        return this;
+    }
+
+    public Celular Build()
+    {
+        if (string.IsNullOrWhiteSpace(_marca) ||
+            string.IsNullOrWhiteSpace(_modelo) ||
+            string.IsNullOrWhiteSpace(_sistemaOperativo))
+        {
+            Logger.Instancia.Log("Intento de crear celular inválido.");
+            throw new InvalidOperationException("El celular debe tener marca, modelo y sistema operativo válidos.");
+        }
+
+        return new Celular(_marca, _modelo, _sistemaOperativo);
+    }
+}
+
+🏭 Factory Method
+public abstract class CelularFactory
+{
+    public abstract Celular CrearCelular(string marca, string modelo, string so);
+}
+
+public class AndroidFactory : CelularFactory
+{
+    public override Celular CrearCelular(string marca, string modelo, string so)
+    {
+        return new CelularBuilder()
+            .ConMarca(marca)
+            .ConModelo(modelo)
+            .ConSistemaOperativo(so)
+            .Build();
+    }
+}
+
+👤 Singleton (Logger thread-safe)
+public sealed class Logger
+{
+    private static readonly Lazy<Logger> _instancia =
+        new Lazy<Logger>(() => new Logger());
+
+    public static Logger Instancia => _instancia.Value;
+
+    private Logger() { }
+
+    public void Log(string mensaje)
+        => Console.WriteLine($"[LOG] {DateTime.Now}: {mensaje}");
+}
+
+▶️ Uso en Programa
+class Program
+{
+    static void Main()
+    {
+        CelularFactory factory = new AndroidFactory();
+
+        try
+        {
+            // ✅ Objeto válido
+            Celular celular = factory.CrearCelular("Samsung", "Galaxy S24", "Android 14");
+            Console.WriteLine(celular);
+
+            // ❌ Objeto inválido (lanza excepción y se registra en Logger)
+            Celular invalido = factory.CrearCelular("", "", "");
+        }
+        catch (Exception ex)
+        {
+            Logger.Instancia.Log($"Error: {ex.Message}");
+        }
+    }
+}
+
+✅ Conclusión
+
+El código inicial permitía crear objetos inconsistentes, lo cual representaba un grave riesgo de diseño.
+
+Con la aplicación de Builder con validación, Factory Method y un Logger Singleton thread-safe:
+
+Se garantiza que cada Celular creado siempre esté en un estado válido.
+
+Se mejora la cohesión y la separación de responsabilidades.
+
+Se refuerza la mantenibilidad y testabilidad del sistema.

--- a/practicas/creacionales/fix/Ricardo Rodriguez Carreras/readme.md
+++ b/practicas/creacionales/fix/Ricardo Rodriguez Carreras/readme.md
@@ -1,0 +1,130 @@
+# Refactor Creacional - Vehículos monolíticos y Logger global
+
+## 🔍 Problemas detectados
+1. **Clase `Vehiculo` viola SRP (Single Responsibility Principle)**  
+   - Tiene múltiples responsabilidades: define atributos, lógica de construcción y validaciones.  
+   - Esto genera dificultad para mantener y extender la clase.
+
+2. **Instancias creadas con `new` directamente en controladores**  
+   - Rompe la idea de Factory Method.  
+   - Si se cambia la forma de instanciar un vehículo, hay que modificar todos los lugares donde se hace `new Vehiculo(...)`.
+
+3. **Singleton `Logger` inseguro en entornos multihilo**  
+   - Implementación actual no controla la concurrencia.  
+   - Puede provocar múltiples instancias simultáneas y pérdida de trazas en logs.
+
+---
+
+## 🛠 Patrones aplicados
+- ✅ **Builder**: Separa la construcción compleja de objetos `Vehiculo` (motor, color, puertas).  
+- ✅ **Factory Method**: Permite crear instancias de vehículos sin depender de `new`.  
+- ✅ **Singleton (thread-safe)**: Se refactoriza el `Logger` usando `Lazy<T>` para garantizar una única instancia segura en multihilo.
+
+---
+
+## 💡 Justificación del cambio
+- Aumenta la **cohesión interna** al dividir responsabilidades.  
+- Incrementa la **testabilidad**, ya que las dependencias pueden ser simuladas fácilmente.  
+- Se gana **flexibilidad ante cambios futuros**, pues ahora se pueden extender las familias de vehículos sin modificar el código cliente.  
+
+---
+
+## 🔄 Impacto
+- Cumplimiento del **Principio de Inversión de Dependencias (DIP)**.  
+- Reducción del **acoplamiento** entre cliente y productos concretos.  
+- Arquitectura lista para **pruebas unitarias** y **mantenimiento ágil**.  
+
+---
+
+## 📌 Ejemplo de Código Refactorizado
+
+### 🚗 Builder para Vehículos
+```csharp
+// Producto
+public class Vehiculo
+{
+    public string Motor { get; set; }
+    public string Color { get; set; }
+    public int Puertas { get; set; }
+
+    public override string ToString()
+        => $"Motor: {Motor}, Color: {Color}, Puertas: {Puertas}";
+}
+
+// Builder
+public interface IVehiculoBuilder
+{
+    void SetMotor(string motor);
+    void SetColor(string color);
+    void SetPuertas(int puertas);
+    Vehiculo Build();
+}
+
+// Implementación concreta del Builder
+public class VehiculoBuilder : IVehiculoBuilder
+{
+    private Vehiculo _vehiculo = new Vehiculo();
+
+    public void SetMotor(string motor) => _vehiculo.Motor = motor;
+    public void SetColor(string color) => _vehiculo.Color = color;
+    public void SetPuertas(int puertas) => _vehiculo.Puertas = puertas;
+
+    public Vehiculo Build()
+    {
+        var result = _vehiculo;
+        _vehiculo = new Vehiculo(); // reinicia para siguiente construcción
+        return result;
+    }
+}
+
+##🏭 Factory Method
+public abstract class VehiculoFactory
+{
+    public abstract Vehiculo CrearVehiculo();
+}
+
+public class SedanFactory : VehiculoFactory
+{
+    public override Vehiculo CrearVehiculo()
+    {
+        var builder = new VehiculoBuilder();
+        builder.SetMotor("1.6L");
+        builder.SetColor("Azul");
+        builder.SetPuertas(4);
+        return builder.Build();
+    }
+}
+
+👤 Singleton (thread-safe)
+public sealed class Logger
+{
+    private static readonly Lazy<Logger> _instancia =
+        new Lazy<Logger>(() => new Logger());
+
+    public static Logger Instancia => _instancia.Value;
+
+    private Logger() { }
+
+    public void Log(string mensaje)
+        => Console.WriteLine($"[LOG] {DateTime.Now}: {mensaje}");
+}
+
+▶️ Uso en Programa
+class Program
+{
+    static void Main()
+    {
+        VehiculoFactory factory = new SedanFactory();
+        Vehiculo auto = factory.CrearVehiculo();
+
+        Console.WriteLine(auto);
+
+        Logger.Instancia.Log("Vehículo creado correctamente.");
+    }
+}
+
+✅ Conclusión
+
+El código inicial presentaba problemas de cohesión, acoplamiento y seguridad en el Singleton.
+Con la aplicación de Builder, Factory Method y Singleton thread-safe, se logró una arquitectura más clara, reutilizable y mantenible, alineada con los principios SOLID.
+


### PR DESCRIPTION
# 🔄 Refactor: Crear objetos sin validar estado

## 📌 Problema
- Los objetos `Celular` podían crearse en estado inválido (sin marca, modelo o sistema operativo).  
- El código cliente usaba `new` directamente, duplicando lógica y mezclando validación con negocio.  

## 🛠️ Solución
- Builder con validación interna.  
- Factory Method para centralizar la creación.  
- Singleton (Logger thread-safe) para registrar intentos inválidos.

## ✅ Impacto
- Objetos siempre válidos por construcción.  
- Código cliente limpio y desacoplado.  
- Preparado para pruebas unitarias y extensiones futuras.

Archivos añadidos: `practicas/creacionales/fix/crear-objetos-sin-validar-estado/readme.md`, `anexo.md`, y código en `Domain/`, `Factories/`, `Infrastructure/`.
