### PR TITLE
peer-review.md

### DIFF
--- a/practicas/comportamiento/temas/fix/Varias clases tienen métodos similares como Ejecutar(), pero cada uno lo hace distinto. ❌ → Falta de abstracción común. ¿Command, Strategy o Template? /review.md
+++ b/practicas/comportamiento/temas/fix/Varias clases tienen métodos similares como Ejecutar(), pero cada uno lo hace distinto. ❌ → Falta de abstracción común. ¿Command, Strategy o Template? /review.md
@@ -1,0 +1,50 @@
+# 🧑‍💻 Revisión de Código - Patrones Estructurales (GoF)
+
+## 👤 Revisor:
+Ricardo Rodríguez Carreras 21212360
+
+## 📌 PR Revisado:
+Rama: practicas/comportamiento/temas/fix/Los métodos para exportar reportes (PDF, Excel, CSV) están todos juntos en una clase enorme. ❌ → Strategy para separar comportamientos./README.md
+
+---
+
+## ✅ Checklist Técnica
+
+| Ítem | ¿Cumple? | Comentarios |
+|------|-----------|-------------|
+| **1. Identifica al menos un code smell estructural real** | ✅ Sí | Se detecta correctamente la violación del Principio de Responsabilidad Única (SRP) y el uso excesivo de condicionales en una sola clase. |
+| **2. Aplica un patrón estructural adecuado** | ✅ Sí | Aunque el patrón *Strategy* pertenece al grupo de **comportamiento**, su uso aquí es justificado para desacoplar las estrategias de exportación. Cumple con OCP y SRP. |
+| **3. La solución es coherente y mejora el diseño** | ✅ Sí | La nueva estructura modulariza las responsabilidades y elimina los `if` innecesarios, haciendo el código extensible y fácil de mantener. |
+| **4. El código es legible y está bien estructurado** | ✅ Sí | Las clases y métodos están bien nombrados (`ExportarPDF`, `ExportarExcel`, `ExportadorContexto`), y la lógica es clara. |
+| **5. El PR está bien documentado y argumentado** | ✅ Sí | Se explica claramente el problema original, la motivación del patrón elegido y la justificación técnica. |
+
+---
+
+## 🧠 Observaciones Técnicas
+
+El código refactorizado demuestra una correcta comprensión del **Principio de Abierto/Cerrado (OCP)** y del **Principio de Responsabilidad Única (SRP)**.  
+Cada formato de exportación se maneja mediante una clase independiente que implementa la interfaz `IExportStrategy`.  
+Esto permite agregar nuevos formatos sin alterar el código existente, lo cual mejora la mantenibilidad y reduce el acoplamiento.
+
+Además, el `ExportadorContexto` cumple bien su rol al delegar la ejecución a la estrategia seleccionada.  
+El código resulta limpio, fácil de extender y alineado con buenas prácticas de diseño.
+
+---
+
+## 🛠️ Sugerencias de Mejora
+
+- Podrías agregar una **fábrica simple (Factory Method)** o un **mapeo de estrategias** para automatizar la selección de la estrategia según un tipo pasado por parámetro, en lugar de instanciarla manualmente cada vez.
+- Considera incluir **tests unitarios** para validar que cada estrategia exporta el mensaje correcto.
+- Si el contexto crece, podrías extraer la lógica de cambio de estrategia en un método más expresivo (`CambiarFormato()`), para mantener el código aún más claro.
+
+---
+
+## 🎯 Entrega Final
+
+
+> Excelente aplicación del patrón Strategy para eliminar condicionales y mejorar la extensibilidad del módulo de exportación.  
+> El diseño demuestra comprensión de los principios SOLID, especialmente SRP y OCP.  
+> Solo se recomienda considerar una fábrica para automatizar la selección de estrategias y agregar pruebas unitarias.  
+> ¡Muy buen trabajo, limpio y bien documentado! 👏
+
+


### PR DESCRIPTION
## 👤 Revisor:
Ricardo Rodríguez Carreras

Rama:
practicas/comportamiento/temas/fix/Los métodos para exportar reportes (PDF, Excel, CSV) están todos juntos en una clase enorme. ❌ → Strategy para separar comportamientos./README.md

Revisión técnica del PR sobre refactorización de la clase ExportadorReportes aplicando el patrón Strategy.
Se valida la correcta eliminación de condicionales, aplicación de SRP/OCP y mejora en la extensibilidad del código.
Incluye comentarios en línea y sugerencias de mejora sobre validación y factoría de estrategias.